### PR TITLE
br & date fixes, related events

### DIFF
--- a/templates/summit/schedule.php
+++ b/templates/summit/schedule.php
@@ -1,12 +1,12 @@
 <p>
-  <i class="calendar icon"></i> <time class="dt-start" datetime="2020-06-26">June 26</time>-<time class="dt-end" datetime="2020-06-27">27</time>, 2020<br>
+  <i class="calendar icon"></i> <time class="dt-start" datetime="2020-06-27">June 27</time>-<time class="dt-end" datetime="2020-06-28">28</time>, 2020<br/>
   <i class="marker icon"></i> <span class="h-card p-location"><span class="p-name">Mozilla</span>, <span class="p-street-address">1120 NW Couch St #320</span>, <span class="p-locality">Portland</span>, <span class="p-region">Oregon</span></span>
 </p>
 
 <div class="schedule-grid">
   <div class="day h-event">
     <div class="header gold-bkg">
-      <time class="dt-start" datetime="2020-06-25T17:30:00-0700">Friday, June 25</time><br>
+      <time class="dt-start" datetime="2020-06-26T17:30:00-0700">Friday, June 26</time><br/>
       <span class="featured p-name">Pre-Summit Meetup</span>
     </div>
     <div class="summary p-description">
@@ -17,7 +17,9 @@
         <li><span class="time">17:30</span> <span class="featured">Pre-Summit Meetup!</span></li>
       </ul>
       <!--
-      <span class="p-location h-card"><a class="p-name u-url" href="http://www.pinestreetpdx.com/">Pine Street Market</a><br><span class="p-street-address">126 SW 2nd St.</span></span>
+      <span class="p-location h-card">
+        <a class="p-name u-url" href="http://www.pinestreetpdx.com/">Pine Street Market</a><br/>
+        <span class="p-street-address">126 SW 2nd St.</span></span>
       <p style="font-size:0.8em; margin-top: 1em;">Pine Street Market is an indoor food hall with a wide variety of food and drink options.</p>
       -->
       <p>TBD</p>
@@ -25,7 +27,7 @@
   </div>
   <div class="day">
     <div class="header orange-bkg">
-      Saturday, June 26<br>
+      Saturday, June 27<br/>
       <span class="featured">Keynotes &amp; Discussions</span>
     </div>
     <div class="summary">
@@ -34,7 +36,7 @@
     <div class="details">
       <ul>
         <li><span class="time">09:00</span> Doors open, badges, coffee, and breakfast!</li>
-        <li><span class="time">10:00</span> <span class="featured"><a href="https://indieweb.org/2019/Schedule#Keynotes">Keynotes</a></span></li>
+        <li><span class="time">10:00</span> <span class="featured"><a href="https://indieweb.org/2020/Schedule#Keynotes">Keynotes</a></span></li>
         <li><span class="time">11:00</span> Lightning Intros &amp; Personal Site Demos</li>
         <li><span class="time">12:00</span> Group photo &amp; decentralized lunch</li>
         <li><span class="time">13:30</span> Session Proposals &amp; Scheduling</li>
@@ -45,7 +47,7 @@
   </div>
   <div class="day">
     <div class="header red-bkg">
-      Sunday, June 27<br>
+      Sunday, June 28<br/>
       <span class="featured">Create, Hack, Demo!</span>
     </div>
     <div class="summary">
@@ -55,7 +57,8 @@
       <ul>
         <li><span class="time">09:00</span> Doors open, badges, coffee, and breakfast!</li>
         <li><span class="time">09:30</span> Day 2 session scheduling</li>
-        <li><span class="time">10:00</span> <span class="featured">IndieWeb Creating:</span> <br>IndieWeb 101, IndieWebifying your WordPress, Dev intro to indieweb building blocks</li>
+        <li><span class="time">10:00</span> <span class="featured">IndieWeb Creating:</span> <br/>
+          IndieWeb 101, IndieWebifying your WordPress, Dev intro to indieweb building blocks</li>
         <li><span class="time">11:00</span> Start creating!</li>
         <li><span class="time">12:00</span> Group photo &amp; catered lunch</li>
         <li><span class="time">13:00</span> Creating sessions continue</li>
@@ -66,7 +69,7 @@
   </div>
 </div>
 
-<br>
+
 <p>Schedule is subject to change. View the <a href="https://indieweb.org/2020/Schedule">full schedule grid</a> on the IndieWeb wiki for the latest updates.</p>
 
 
@@ -75,33 +78,33 @@
 
 <div class="keynote-speakers">
 
-  <div class="speaker">
-    <a href="https://tantek.com/"><img src="/images/tantek.jpg"></a>
-    <p class="name">Tantek<br> Çelik</p>
+  <div class="speaker h-card">
+    <a class="u-url" href="https://tantek.com/"><img class="u-photo" src="/images/tantek.jpg"></a>
+    <p class="name p-name">Tantek<br/> Çelik</p>
     <p class="role">State of the IndieWeb</p>
   </div>
 
-  <div class="speaker">
-    <a href="https://kitt.hodsden.org/"><img src="/images/kitt-hodsden.jpg"></a>
-    <p class="name">Kitt<br> Hodsden</p>
+  <div class="speaker h-card">
+    <a class="u-url" href="https://kitt.hodsden.org/"><img class="u-photo" src="/images/kitt-hodsden.jpg"></a>
+    <p class="name p-name">Kitt<br/> Hodsden</p>
     <p class="role">On Contractions &amp; Expansions</p>
   </div>
 
-  <div class="speaker">
-    <a href="https://mjordan.codes/"><img src="/images/mjordan.jpg"></a>
-    <p class="name">mJordan<br>&nbsp;</p>
+  <div class="speaker h-card">
+    <a class="u-url" href="https://mjordan.codes/"><img class="u-photo" src="/images/mjordan.jpg"></a>
+    <p class="name p-name">mJordan<br/>&nbsp;</p>
     <p class="role">Changing My Domain</p>
   </div>
 
-  <div class="speaker">
-    <a href="https://martymcgui.re/"><img src="/images/schmarty.jpg"></a>
-    <p class="name">Marty<br> McGuire</p>
+  <div class="speaker h-card">
+    <a class="u-url" href="https://martymcgui.re/"><img class="u-photo" src="/images/schmarty.jpg"></a>
+    <p class="name p-name">Marty<br/> McGuire</p>
     <p class="role">Own Your Mobile Experience</p>
   </div>
 
-  <div class="speaker">
-    <a href="https://jacky.wtf/"><img src="/images/jacky.jpg"></a>
-    <p class="name">Jacky<br> Alciné</p>
+  <div class="speaker h-card">
+    <a class="u-url" href="https://jacky.wtf/"><img class="u-photo" src="/images/jacky.jpg"></a>
+    <p class="name p-name">Jacky<br/> Alciné</p>
     <p class="role">Making the IndieWeb for All</p>
   </div>
 
@@ -110,29 +113,31 @@
 
 
 
-<br>
 
-<!--
 <h3>Related Events</h3>
 
-<p>There's a lot happening the week of IndieWeb Summit! Here are some related events. These events have their own registration process and community guidelines so please register on their respective websites!</p>
--->
+<p>There's a lot happening the week of IndieWeb Summit! 
+  Here are some related events. 
+  These events have their own registration process and community guidelines so please register on their respective websites!
+  More related events will be added as we learn about them!
+  Want to recommend a related event in Portland? Let us know in the
+  <a href="https://chat.indieweb.org/meta">IndieWeb meta chat</a>!
+</p>
+
 
 <!--
 <div class="related-event">
-  <h4>Tuesday, June 25: Donut.js</h4>
+  <h4>Tuesday, June 23: Donut.js</h4>
   <p><b><a href="https://donutjs.club/">Donut.js</a></b> is a monthly meet-up in Portland, OR with a handful of wonderful talks on tech, creativity, community, and the places they come together.</p>
   <p><a href="https://donutjs.club/" class="register-btn">Register Here</a> ($10 or free)</p>
 </div>
 -->
 
-<!--
 <div class="related-event">
-  <h4>Wednesday, June 26: Homebrew Website Club</h4>
-  <p><b><a href="https://indieweb.org/events/2019-06-26-homebrew-website-club#Portland">Homebrew Website Club</a></b> is a meetup of people passionate about or interested in creating, improving, building, designing their own website.</p>
-  <p><a href="https://indieweb.org/events/2019-06-26-homebrew-website-club#Portland" class="register-btn">RSVP Here</a> (free, or just show up!)</p>
+  <h4>Wednesday, June 24: Homebrew Website Club</h4>
+  <p><b><a href="https://events.indieweb.org/2020/06/homebrew-website-club-portland-ldy47SGzOy6E">Homebrew Website Club</a></b> is a meetup of people passionate about or interested in creating, improving, building, designing their own website.</p>
+  <p><a href="https://events.indieweb.org/2020/06/homebrew-website-club-portland-ldy47SGzOy6E" class="register-btn">RSVP Here</a> (free, or just show up!)</p>
 </div>
--->
 
 <style>
 .related-event {

--- a/templates/summit/schedule.php
+++ b/templates/summit/schedule.php
@@ -78,33 +78,33 @@
 
 <div class="keynote-speakers">
 
-  <div class="speaker h-card">
-    <a class="u-url" href="https://tantek.com/"><img class="u-photo" src="/images/tantek.jpg"></a>
-    <p class="name p-name">Tantek<br/> Çelik</p>
+  <div class="speaker">
+    <a href="https://tantek.com/"><img src="/images/tantek.jpg"></a>
+    <p class="name">Tantek<br/> Çelik</p>
     <p class="role">State of the IndieWeb</p>
   </div>
 
-  <div class="speaker h-card">
-    <a class="u-url" href="https://kitt.hodsden.org/"><img class="u-photo" src="/images/kitt-hodsden.jpg"></a>
-    <p class="name p-name">Kitt<br/> Hodsden</p>
+  <div class="speaker">
+    <a href="https://kitt.hodsden.org/"><img src="/images/kitt-hodsden.jpg"></a>
+    <p class="name">Kitt<br/> Hodsden</p>
     <p class="role">On Contractions &amp; Expansions</p>
   </div>
 
-  <div class="speaker h-card">
-    <a class="u-url" href="https://mjordan.codes/"><img class="u-photo" src="/images/mjordan.jpg"></a>
-    <p class="name p-name">mJordan<br/>&nbsp;</p>
+  <div class="speaker">
+    <a href="https://mjordan.codes/"><img src="/images/mjordan.jpg"></a>
+    <p class="name">mJordan<br/>&nbsp;</p>
     <p class="role">Changing My Domain</p>
   </div>
 
-  <div class="speaker h-card">
-    <a class="u-url" href="https://martymcgui.re/"><img class="u-photo" src="/images/schmarty.jpg"></a>
-    <p class="name p-name">Marty<br/> McGuire</p>
+  <div class="speaker">
+    <a href="https://martymcgui.re/"><img src="/images/schmarty.jpg"></a>
+    <p class="name">Marty<br/> McGuire</p>
     <p class="role">Own Your Mobile Experience</p>
   </div>
 
-  <div class="speaker h-card">
-    <a class="u-url" href="https://jacky.wtf/"><img class="u-photo" src="/images/jacky.jpg"></a>
-    <p class="name p-name">Jacky<br/> Alciné</p>
+  <div class="speaker">
+    <a href="https://jacky.wtf/"><img src="/images/jacky.jpg"></a>
+    <p class="name">Jacky<br/> Alciné</p>
     <p class="role">Making the IndieWeb for All</p>
   </div>
 


### PR DESCRIPTION
self-closed br tags to help with github markup validation, line breaks to help some editing, remove unnecessary br markup (please use styling to add more space if needed), speaker h-cards (for when they're figured out), fixed various former 2019 dates copy/pastes and incorrect June 25-27 dates, re-added related events including HWC PDX the week of since we already have an event link for it!